### PR TITLE
Exporting packages so that other plugins can use the startexplorer API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.bak
 *~
+powermock-mockito-junit-1.4.11

--- a/plugin/META-INF/MANIFEST.MF
+++ b/plugin/META-INF/MANIFEST.MF
@@ -16,3 +16,5 @@ Require-Bundle: org.eclipse.ui,
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: lib/json-simple-1.1.1.jar,
  .
+Export-Package: de.bastiankrol.startexplorer,
+ de.bastiankrol.startexplorer.crossplatform


### PR DESCRIPTION
Just exported the packages so that I could use its API to open an external folder.
