### PR TITLE
Providing a way to use elements in the tree which adapt to URI.class.

### DIFF
--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -101,9 +101,18 @@
         id="de.bastiankrol.startexplorer.menuPackageExplorer">
         <visibleWhen>
           <with variable="activeMenuSelection">
-            <iterate>
-              <adapt type="org.eclipse.core.resources.IResource" />
-            </iterate>
+            <or>
+               <iterate>
+                  <adapt
+                        type="org.eclipse.core.resources.IResource">
+                  </adapt>
+               </iterate>
+               <iterate>
+                  <adapt
+                        type="java.net.URI">
+                  </adapt>
+               </iterate>
+            </or>
           </with>
         </visibleWhen>
         <command

--- a/plugin/src/de/bastiankrol/startexplorer/handlers/delegates/AbstractStartFromResourceHandlerDelegate.java
+++ b/plugin/src/de/bastiankrol/startexplorer/handlers/delegates/AbstractStartFromResourceHandlerDelegate.java
@@ -1,8 +1,10 @@
 package de.bastiankrol.startexplorer.handlers.delegates;
 
-import static de.bastiankrol.startexplorer.Activator.*;
+import static de.bastiankrol.startexplorer.Activator.getLogFacility;
+import static de.bastiankrol.startexplorer.Activator.getPluginContext;
 
 import java.io.File;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -152,6 +154,14 @@ public abstract class AbstractStartFromResourceHandlerDelegate extends
       if (!(selectedObject instanceof IResource || (selectedObject instanceof IAdaptable && ((IAdaptable) selectedObject)
           .getAdapter(IResource.class) != null)))
       {
+        if(selectedObject instanceof IAdaptable){
+          IAdaptable iAdaptable = (IAdaptable) selectedObject;
+          URI uri = (URI) iAdaptable.getAdapter(URI.class);
+          if(uri != null){
+            fileList.add(new File(uri));
+            return fileList;
+          }
+        }
         getPluginContext()
             .getLogFacility()
             .logWarning(


### PR DESCRIPTION
In PyDev there are some elements which are shown in the tree which are external resources (such as elements from the interpreter), which are not IResources but still map to a file.

This patch adds support for startexplorer for dealing with those elements (which adapt to URI.class).
